### PR TITLE
Remove Styleguidekit Assets Default Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,5 @@
     "issues":         "https://github.com/pattern-lab/styleguidekit-twig-default/issues",
     "wiki":           "http://patternlab.io/docs/",
     "source":         "https://github.com/pattern-lab/styleguidekit-twig-default/releases"
-  },
-  "require": {
-    "pattern-lab/styleguidekit-assets-default": "^3.0.0"
   }
 }


### PR DESCRIPTION
Corresponds with https://github.com/drupal-pattern-lab/edition-php-twig-standard/pull/1 so dependencies are centralized in one place (particularly code that's are required by the project itself vs a specific sub-dependency).

Adding this in to the main PL Twig Edition fork separately