### PR TITLE
Add Package.json for NPM Install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "styleguidekit-twig-default",
+  "description": "The default Twig-based StyleguideKit for Pattern Lab. Contains styles and mark-up for Pattern Lab's front-end.",
+  "version": "3.0.2",
+  "dependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/drupal-pattern-lab/styleguidekit-twig-default.git"
+  },
+  "bugs": "https://github.com/drupal-pattern-lab/styleguidekit-twig-default/issues",
+  "authors": [
+    {
+      "name": "Dave Olsen",
+      "email": "dmolsen@gmail.com",
+      "homepage": "http://dmolsen.com",
+      "role": "Lead Developer"
+    },
+    {
+      "name": "Brad Frost",
+      "homepage": "http://bradfrostweb.com",
+      "role": "Creator"
+    },
+    {
+      "name": "Salem Ghoweri",
+      "email": "me@salemghoweri.com",
+      "role": "Developer"
+    }
+  ],
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -12,18 +12,20 @@
     {
       "name": "Dave Olsen",
       "email": "dmolsen@gmail.com",
-      "homepage": "http://dmolsen.com",
-      "role": "Lead Developer"
+      "url": "http://dmolsen.com",
     },
     {
       "name": "Brad Frost",
-      "homepage": "http://bradfrostweb.com",
+      "url": "http://bradfrostweb.com",
       "role": "Creator"
     },
     {
       "name": "Salem Ghoweri",
-      "email": "me@salemghoweri.com",
-      "role": "Developer"
+      "url": "https://github.com/sghoweri"
+    },
+    {
+      "name": "Evan Lovely",
+      "url": "https://github.com/EvanLovely"
     }
   ],
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     {
       "name": "Dave Olsen",
       "email": "dmolsen@gmail.com",
-      "url": "http://dmolsen.com",
+      "url": "http://dmolsen.com"
     },
     {
       "name": "Brad Frost",


### PR DESCRIPTION
Adding in a package.json to allow Styleguidekit Twig templates to get installed via npm as well -- matches similar setup to what @bmuenzenmeyer has with the styleguidekit-mustache-default project.

PR also open on main PL project here https://github.com/pattern-lab/styleguidekit-twig-default/pull/6 to get this change in across the board.